### PR TITLE
PB-208: add a global weights reader

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,7 +104,8 @@ def test_invalid_logging_config(
     )
 
 
-def test_load_valid_config(  # pylint: disable=redefined-outer-name
+def test_load_valid_config(
+    # pylint: disable=redefined-outer-name
     config_sample: dict,
 ) -> None:
     """

--- a/tests/test_participant.py
+++ b/tests/test_participant.py
@@ -173,7 +173,8 @@ def test_get_set_pytorch_weights(  # pylint: disable=redefined-outer-name
 
 
 def test_update_metrics(
-    participant: Participant,  # pylint: disable=redefined-outer-name
+    # pylint: disable=redefined-outer-name
+    participant: Participant,
 ) -> None:
     """Test the metrics updating.
 
@@ -254,7 +255,8 @@ def test_update_metrics(
 
 
 def test_update_metrics_overwrite(
-    participant: Participant,  # pylint: disable=redefined-outer-name
+    # pylint: disable=redefined-outer-name
+    participant: Participant,
 ) -> None:
     """Test the metrics updating with overwriting.
 


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/PB-208

### Summary

Add code for reading aggregated weights from S3.
We re-used the same abstractions that we went for in https://github.com/xainag/xain-fl/pull/254, therefore the AbstractStore class is split in two separate abstract classes:

- AbstractLocalWeightsWriter is used to upload the participant weights
  to S3 at the end of the round
- AbstractGlobalWeightsReader is used to download the global weights
  from S3 before training


---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
